### PR TITLE
7 - api now allows to post comments into the db

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -191,3 +191,58 @@ describe("GET /api/articles/:article_id/comments", () => {
       });
   })
 })
+
+describe("POST /api/articles/:article_id/comments", () => {
+  test('POST: 201 inserts a new comment to the db and sends the new comment back to the client.', () => {
+    const newComment = {
+      username: "icellusedkars",
+      body: "Ik hou van Gouda kaas!"
+    }
+
+    return request(app)
+    .post('/api/articles/1/comments')
+    .send(newComment)
+    .expect(201)
+    .then((response) => {
+      const {body} = response;
+      expect(body.comment.author).toBe("icellusedkars")
+      expect(body.comment.body).toBe("Ik hou van Gouda kaas!")
+    })
+  })
+
+  test('Should return an error if the username doesnt exist', () => {
+    const newComment = {
+      username: "Kerstman159",
+      body: "Hallo!"
+    }
+
+    return request(app)
+    .post('/api/articles/1/comments')
+    .send(newComment)
+    .expect(400)
+    .then((response) => {
+      const { body } = response;
+      const {msg} = body;
+      expect(msg).toBe(("Bad request"))
+    })
+  })
+
+  test('POST: 400 responds with a status and error message when provided with a bad comment, for example no username!', () => {
+
+    const newComment = {
+      body: "Thats cool!"
+    }
+
+
+    return request(app)
+    .post('/api/articles/1/comments')
+    .send(newComment)
+    .expect(400)
+    .then((response) => {
+      const {body} = response
+      const {msg} = body;
+
+      expect(msg).toBe(("Bad request"))
+    })
+  })
+})

--- a/app.js
+++ b/app.js
@@ -5,9 +5,11 @@ const {
   getArticleId,
   getArticles,
   getArticleComments,
+  postArticleComment,
 } = require("./db/Controllers/api.controller");
 
 const app = express();
+app.use(express.json())
 
 app.get("/api", getApiDocu);
 
@@ -19,11 +21,18 @@ app.get("/api/articles", getArticles);
 
 app.get("/api/articles/:article_id/comments", getArticleComments)
 
+app.post("/api/articles/:article_id/comments", postArticleComment)
+
 
 
 app.use((err, req, res, next) => {
-  //console.log(err)
   if (err.code === "22P02") {
+    res.status(400).send({msg: "Bad request"})
+  } else next(err)
+})
+
+app.use((err, req, res, next) => {
+  if(err.code === "23503" || err.code === "23502") {
     res.status(400).send({msg: "Bad request"})
   } else next(err)
 })

--- a/db/Controllers/api.controller.js
+++ b/db/Controllers/api.controller.js
@@ -4,6 +4,7 @@ const {
   readArticleId,
   readArticles,
   readArticleComments,
+  insertComment,
 } = require("../models/api.model");
 
 exports.getApiDocu = (req, res) => {
@@ -61,3 +62,19 @@ exports.getArticleComments = (req, res, next) => {
       next(err);
     });
 };
+
+exports.postArticleComment = (req, res, next) => {
+
+
+  const { article_id } = req.params
+  const { username, body } = req.body
+
+  
+
+  insertComment(username, body, article_id).then((comment) => {
+    res.status(201).send({comment})
+  })
+  .catch((err) => {
+    next(err)
+  })
+}

--- a/db/models/api.model.js
+++ b/db/models/api.model.js
@@ -1,3 +1,4 @@
+const { user } = require("pg/lib/defaults");
 const db = require("../connection");
 
 function readTopics() {
@@ -54,6 +55,19 @@ function readArticleComments(article_id) {
 
 }
 
+function insertComment(username, body, article_id) {
+
+  return db.query('INSERT INTO comments (author, body, article_id) VALUES ($1, $2, $3) RETURNING *;',
+    [username, body, article_id]
+  )
+  .then((result) => {
+    if(result.rows.length === 0){
+      return Promise.reject()
+    }
+    return result.rows[0]
+  })
+}
 
 
-module.exports = { readTopics, readArticleId, readArticles, readArticleComments};
+
+module.exports = { readTopics, readArticleId, readArticles, readArticleComments, insertComment};


### PR DESCRIPTION

### Feature: POST /api/articles/:article_id/comments

**Summary**
This Pull Request adds a new FEATURE to the accessible endpoint : /api/articles/:article_id/comments

You can now insert new comments into the DB by making requests- provided that the username DOES exist in the database.

**Error Handling**

With the previously received feedback, I included more extensive error handling and management. Due to research done on error codes, the inserted data will give back the appropriate error codes given the circumstance.

The errors that have been tested for is : 400 & 500.

**Testing**
Integration tests have been added to ensure only existing USERS are allowed to add new comments. If the user exist, new comments can be made, if not- the appropriate error response will be given towards the user.
